### PR TITLE
make NetworkAdapterInfo and Version public

### DIFF
--- a/src/ndisapi.rs
+++ b/src/ndisapi.rs
@@ -35,6 +35,9 @@ mod static_api;
 // Re-exports the `driver` submodule
 pub use crate::driver::*;
 
+// Re-export already public members in `defs.rs`
+pub use crate::ndisapi::defs::{NetworkAdapterInfo, Version};
+
 /// The `Ndisapi` struct represents an instance of the NDIS filter driver that provides access to network adapters and packets.
 ///
 /// This struct is used to communicate with the NDIS filter driver and access its functionalities. It contains a single field, `driver_handle`,


### PR DESCRIPTION
- They have public methods but they cannot be used as struct members or as members in abstraction