### PR TITLE
Extend NDISAPI with Asynchronous Functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndisapi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Vadim Smirnov <vadim@ntkernel.com>"]
 description = "Windows Packet Filter API for Rust"
@@ -13,6 +13,10 @@ readme = "README.md"
 
 [dependencies]
 bitflags = "2.1.0"
+futures = { version = "0.3.28", optional = true }
+
+[features]
+async = ["futures"]
 
 [dependencies.windows]
 version = "0.48.0"
@@ -31,3 +35,13 @@ features = [
 etherparse = "0.13"
 clap = {version = "4.0.32", features = ["derive"]}
 ctrlc = "3.2.4"
+futures = "0.3.28"
+tokio = { version = "1.28.1", features = ["full"] }
+
+[[example]]
+name = "async_passthru"
+required-features = ["async"]
+
+[[example]]
+name = "async_packthru"
+required-features = ["async"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-ndisapi = "0.2.0"
+ndisapi = "0.3.0"
 ```
 
 ## Usage

--- a/examples/async_packthru.rs
+++ b/examples/async_packthru.rs
@@ -1,0 +1,276 @@
+use clap::Parser;
+use etherparse::{InternetSlice::*, LinkSlice::*, TransportSlice::*, *};
+use ndisapi::NdisapiAdapter;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use windows::{
+    core::Result,
+};
+
+const PACKET_NUMBER: usize = 256;
+
+/// This async function reads from the given NdisapiAdapter and handles the packets accordingly.
+async fn async_loop(adapter: &mut NdisapiAdapter) -> Result<()> {
+    // Set the adapter mode to MSTCP_FLAG_SENT_RECEIVE_TUNNEL.
+    adapter.set_adapter_mode(ndisapi::FilterFlags::MSTCP_FLAG_SENT_RECEIVE_TUNNEL)?;
+
+    // Initialize a vector of IntermediateBuffers, `ibs`, to store network packet data. 
+    // Each IntermediateBuffer is heap-allocated, providing a structure to handle raw packet data.
+    let mut ibs: Vec<ndisapi::IntermediateBuffer> = vec![Default::default(); PACKET_NUMBER];
+
+    // Initialize three vectors of EthPackets that will be used for different operations: 
+    // `to_read` for reading packets from the network adapter,
+    // `to_adapter` for sending packets to the network adapter, 
+    // and `to_mstcp` for sending packets upwards to the network stack.
+    let mut to_read: Vec<ndisapi::EthPacket> = Vec::new();
+    let mut to_adapter: Vec<ndisapi::EthPacket> = Vec::new();
+    let mut to_mstcp: Vec<ndisapi::EthPacket> = Vec::new();
+
+    // For each IntermediateBuffer in `ibs`, create an EthPacket, which will provide a handle
+    // for the NDISAPI driver to interact with the raw packet data in the IntermediateBuffer.
+    //
+    // # Safety
+    //
+    // This operation is safe as long as the `IntermediateBuffer` (ib) outlives 
+    // the EthPacket arrays `to_read`, `to_adapter`, and `to_mstcp`. The `ib` instance is owned by `ibs`, 
+    // which is guaranteed not to be dropped before these EthPacket arrays. Therefore, the raw pointer 
+    // inside the EthPacket will always reference a valid IntermediateBuffer during its lifetime.
+    for ib in ibs.iter_mut() {
+        let packet = unsafe { ndisapi::EthPacket::new(ib) };
+        to_read.push(packet);
+    }
+
+    loop {
+        // Read a packet from the adapter.
+        let packets_read = match adapter.read_packets::<PACKET_NUMBER>(&to_read).await {
+            Ok(packets_read) => {
+                if packets_read == 0 {
+                    println!("No packets read. Continue reading.");
+                    continue;
+                }
+                else {
+                    packets_read
+                }
+            }
+            Err(_) => {
+                continue;
+            }
+        };
+
+        println!("=======================================================================================================");
+
+        // Process each packet.
+        for i in 0..packets_read {
+            let mut eth = to_read[i];
+            let packet = unsafe { eth.get_buffer_mut() };
+
+            // Print packet direction and remaining packets.
+            if packet.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
+                println!(
+                    "\nMSTCP --> Interface ({} bytes) \n",
+                    packet.get_length(),
+                );
+            } else {
+                println!(
+                    "\nInterface --> MSTCP ({} bytes) \n",
+                    packet.get_length(),
+                );
+            }
+
+            // Print packet information
+            print_packet_info(packet);
+
+            if packet.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
+                to_adapter.push(eth);
+            } else {
+                to_mstcp.push(eth);
+            }
+        }
+
+        // Re-inject packets back into the network stack
+        if to_adapter.len() > 0 {
+            match adapter.send_packets_to_adapter::<PACKET_NUMBER>(&to_adapter) {
+                Ok(_) => {}
+                Err(err) => println!("Error sending packet to adapter. Error code = {err}"),
+            }
+            to_adapter.clear();
+        }
+
+        if to_mstcp.len() > 0 {
+            match  adapter.send_packets_to_mstcp::<PACKET_NUMBER>(&to_mstcp) {
+                Ok(_) => {}
+                Err(err) => println!("Error sending packet to mstcp. Error code = {err}"),
+            };
+            to_mstcp.clear();
+        }
+    }
+}
+
+/// This async function runs the main logic of the program.
+async fn main_async(adapter: &mut NdisapiAdapter) {
+    // Prompts the user to press ENTER to exit.
+    println!("Press ENTER to exit");
+
+    // Initializes a channel for communication between this function and a spawned thread.
+    // `tx` is the transmitter and `rx` is the receiver end of the channel.
+    let (tx, rx) = oneshot::channel::<()>();
+
+    // Spawns a new thread using Tokio's runtime, that waits for the user to press ENTER.
+    tokio::spawn(async move {
+        let mut line = String::new();
+        std::io::stdin().read_line(&mut line).unwrap();
+
+        // Sends a message through the channel when the user presses ENTER.
+        let _ = tx.send(());
+    });
+
+    // Waits for either the server to return a result or the thread with `rx` to receive a message.
+    // This is achieved by using the select! macro which polls multiple futures and blocks until one of them is ready.
+    let result = tokio::select! {
+        // The async_loop function reads from the adapter and processes the packets.
+        result = async_loop(adapter) => result,
+        // If the receiver end of the channel receives a message, the program prints "Shutting down..." and returns Ok(()).
+        _ = rx => {
+            println!("Shutting down...");
+            Ok(()) // Thread returns Ok() if it receives the message successfully.
+        }
+    };
+
+    // Prints any errors that may have occurred during the program's execution.
+    if let Err(e) = result {
+        eprintln!("Server error: {}", e);
+    }
+}
+
+/// A struct representing the command line arguments.
+#[derive(Parser)]
+struct Cli {
+    /// Network interface index (please use listadapters example to determine the right one)
+    #[clap(short, long)]
+    interface_index: usize,
+}
+
+// The main function of the program.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Parsing command line arguments.
+    let Cli {
+        mut interface_index,
+    } = Cli::parse();
+
+    // Decrement interface index to match zero-based index.
+    interface_index -= 1;
+
+    // Create a new Ndisapi driver instance.
+    let driver = Arc::new(
+        ndisapi::Ndisapi::new("NDISRD")
+            .expect("WinpkFilter driver is not installed or failed to load!"),
+    );
+
+    // Print the detected version of the Windows Packet Filter.
+    println!(
+        "Detected Windows Packet Filter version {}",
+        driver.get_version()?
+    );
+
+    // Get a list of TCP/IP bound adapters in the system.
+    let adapters = driver.get_tcpip_bound_adapters_info()?;
+
+    // Check if the selected interface index is within the range of available interfaces.
+    if interface_index + 1 > adapters.len() {
+        panic!("Interface index is beyond the number of available interfaces");
+    }
+
+    // Print the name of the selected interface.
+    println!("Using interface {}", adapters[interface_index].get_name(),);
+
+    // Create a new instance of NdisapiAdapter with the selected interface.
+    let mut adapter =
+        NdisapiAdapter::new(Arc::clone(&driver), adapters[interface_index].get_handle()).unwrap();
+
+    // Execute the main_async function using the previously defined adapter.
+    main_async(&mut adapter).await;
+    Ok(())
+}
+
+/// Print detailed information about a network packet.
+///
+/// This function takes an `IntermediateBuffer` containing a network packet and prints various
+/// details about the packet, such as Ethernet, IPv4, IPv6, ICMPv4, ICMPv6, UDP, and TCP information.
+///
+/// # Arguments
+///
+/// * `packet` - A mutable reference to an `ndisapi::IntermediateBuffer` containing the network packet.
+///
+/// # Examples
+///
+/// ```no_run
+/// let mut packet: ndisapi::IntermediateBuffer = ...;
+/// print_packet_info(&mut packet);
+/// ```
+fn print_packet_info(packet: &mut ndisapi::IntermediateBuffer) {
+    // Attempt to create a SlicedPacket from the Ethernet frame.
+    match SlicedPacket::from_ethernet(&packet.buffer.0) {
+        // If there's an error, print it.
+        Err(value) => println!("Err {value:?}"),
+
+        // If successful, proceed with printing packet information.
+        Ok(value) => {
+            // Print Ethernet information if available.
+            if let Some(Ethernet2(value)) = value.link {
+                println!(
+                    " Ethernet {} => {}",
+                    ndisapi::MacAddress::from_slice(&value.source()[..]).unwrap(),
+                    ndisapi::MacAddress::from_slice(&value.destination()[..]).unwrap(),
+                );
+            }
+
+            // Print IP information if available.
+            match value.ip {
+                Some(Ipv4(value, extensions)) => {
+                    println!(
+                        "  Ipv4 {:?} => {:?}",
+                        value.source_addr(),
+                        value.destination_addr()
+                    );
+                    if !extensions.is_empty() {
+                        println!("    {extensions:?}");
+                    }
+                }
+                Some(Ipv6(value, extensions)) => {
+                    println!(
+                        "  Ipv6 {:?} => {:?}",
+                        value.source_addr(),
+                        value.destination_addr()
+                    );
+                    if !extensions.is_empty() {
+                        println!("    {extensions:?}");
+                    }
+                }
+                None => {}
+            }
+
+            // Print transport layer information if available.
+            match value.transport {
+                Some(Icmpv4(value)) => println!(" Icmpv4 {value:?}"),
+                Some(Icmpv6(value)) => println!(" Icmpv6 {value:?}"),
+                Some(Udp(value)) => println!(
+                    "   UDP {:?} -> {:?}",
+                    value.source_port(),
+                    value.destination_port()
+                ),
+                Some(Tcp(value)) => {
+                    println!(
+                        "   TCP {:?} -> {:?}",
+                        value.source_port(),
+                        value.destination_port()
+                    );
+                }
+                Some(Unknown(ip_protocol)) => {
+                    println!("  Unknown Protocol (ip protocol number {ip_protocol:?})")
+                }
+                None => {}
+            }
+        }
+    }
+}

--- a/examples/async_passthru.rs
+++ b/examples/async_passthru.rs
@@ -1,0 +1,222 @@
+use clap::Parser;
+use etherparse::{InternetSlice::*, LinkSlice::*, TransportSlice::*, *};
+use ndisapi::NdisapiAdapter;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use windows::{
+    core::Result,
+};
+
+/// This async function reads from the given NdisapiAdapter and handles the packets accordingly.
+async fn async_loop(adapter: &mut NdisapiAdapter) -> Result<()> {
+    // Set the adapter mode to MSTCP_FLAG_SENT_RECEIVE_TUNNEL.
+    adapter.set_adapter_mode(ndisapi::FilterFlags::MSTCP_FLAG_SENT_RECEIVE_TUNNEL)?;
+
+    // Allocate single IntermediateBuffer on the stack.
+    let mut ib = ndisapi::IntermediateBuffer::default();
+
+    // Initialize EthPacket to pass to driver API.
+    let packet = ndisapi::EthPacket {
+        buffer: &mut ib as *mut ndisapi::IntermediateBuffer,
+    };
+
+    loop {
+        // Read a packet from the adapter.
+        let result = adapter.read_packet(packet).await;
+        if let Err(_) = result {
+            continue;
+        }
+
+        // Print packet information.
+        if ib.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
+            println!("\nMSTCP --> Interface ({} bytes)\n", ib.get_length(),);
+        } else {
+            println!("\nInterface --> MSTCP ({} bytes)\n", ib.get_length(),);
+        }
+
+        // Print some information about the sliced packet.
+        print_packet_info(&mut ib);
+
+        // Re-inject the packet back into the network stack.
+        if ib.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
+            match adapter.send_packet_to_adapter(packet) {
+                Ok(_) => {}
+                Err(err) => println!("Error sending packet to adapter. Error code = {err}"),
+            };
+        } else {
+            match adapter.send_packet_to_mstcp(packet) {
+                Ok(_) => {}
+                Err(err) => println!("Error sending packet to mstcp. Error code = {err}"),
+            }
+        }
+    }
+}
+
+/// This async function runs the main logic of the program.
+async fn main_async(adapter: &mut NdisapiAdapter) {
+    // Prompts the user to press ENTER to exit.
+    println!("Press ENTER to exit");
+
+    // Initializes a channel for communication between this function and a spawned thread.
+    // `tx` is the transmitter and `rx` is the receiver end of the channel.
+    let (tx, rx) = oneshot::channel::<()>();
+
+    // Spawns a new thread using Tokio's runtime, that waits for the user to press ENTER.
+    tokio::spawn(async move {
+        let mut line = String::new();
+        std::io::stdin().read_line(&mut line).unwrap();
+
+        // Sends a message through the channel when the user presses ENTER.
+        let _ = tx.send(());
+    });
+
+    // Waits for either the server to return a result or the thread with `rx` to receive a message.
+    // This is achieved by using the select! macro which polls multiple futures and blocks until one of them is ready.
+    let result = tokio::select! {
+        // The async_loop function reads from the adapter and processes the packets.
+        result = async_loop(adapter) => result,
+        // If the receiver end of the channel receives a message, the program prints "Shutting down..." and returns Ok(()).
+        _ = rx => {
+            println!("Shutting down...");
+            Ok(()) // Thread returns Ok() if it receives the message successfully.
+        }
+    };
+
+    // Prints any errors that may have occurred during the program's execution.
+    if let Err(e) = result {
+        eprintln!("Server error: {}", e);
+    }
+}
+
+/// A struct representing the command line arguments.
+#[derive(Parser)]
+struct Cli {
+    /// Network interface index (please use listadapters example to determine the right one)
+    #[clap(short, long)]
+    interface_index: usize,
+}
+
+// The main function of the program.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Parsing command line arguments.
+    let Cli {
+        mut interface_index,
+    } = Cli::parse();
+
+    // Decrement interface index to match zero-based index.
+    interface_index -= 1;
+
+    // Create a new Ndisapi driver instance.
+    let driver = Arc::new(
+        ndisapi::Ndisapi::new("NDISRD")
+            .expect("WinpkFilter driver is not installed or failed to load!"),
+    );
+
+    // Print the detected version of the Windows Packet Filter.
+    println!(
+        "Detected Windows Packet Filter version {}",
+        driver.get_version()?
+    );
+
+    // Get a list of TCP/IP bound adapters in the system.
+    let adapters = driver.get_tcpip_bound_adapters_info()?;
+
+    // Check if the selected interface index is within the range of available interfaces.
+    if interface_index + 1 > adapters.len() {
+        panic!("Interface index is beyond the number of available interfaces");
+    }
+
+    // Print the name of the selected interface.
+    println!("Using interface {}", adapters[interface_index].get_name(),);
+
+    // Create a new instance of NdisapiAdapter with the selected interface.
+    let mut adapter =
+        NdisapiAdapter::new(Arc::clone(&driver), adapters[interface_index].get_handle()).unwrap();
+
+    // Execute the main_async function using the previously defined adapter.
+    main_async(&mut adapter).await;
+    Ok(())
+}
+
+/// Print detailed information about a network packet.
+///
+/// This function takes an `IntermediateBuffer` containing a network packet and prints various
+/// details about the packet, such as Ethernet, IPv4, IPv6, ICMPv4, ICMPv6, UDP, and TCP information.
+///
+/// # Arguments
+///
+/// * `packet` - A mutable reference to an `ndisapi::IntermediateBuffer` containing the network packet.
+///
+/// # Examples
+///
+/// ```no_run
+/// let mut packet: ndisapi::IntermediateBuffer = ...;
+/// print_packet_info(&mut packet);
+/// ```
+fn print_packet_info(packet: &mut ndisapi::IntermediateBuffer) {
+    // Attempt to create a SlicedPacket from the Ethernet frame.
+    match SlicedPacket::from_ethernet(&packet.buffer.0) {
+        // If there's an error, print it.
+        Err(value) => println!("Err {value:?}"),
+
+        // If successful, proceed with printing packet information.
+        Ok(value) => {
+            // Print Ethernet information if available.
+            if let Some(Ethernet2(value)) = value.link {
+                println!(
+                    " Ethernet {} => {}",
+                    ndisapi::MacAddress::from_slice(&value.source()[..]).unwrap(),
+                    ndisapi::MacAddress::from_slice(&value.destination()[..]).unwrap(),
+                );
+            }
+
+            // Print IP information if available.
+            match value.ip {
+                Some(Ipv4(value, extensions)) => {
+                    println!(
+                        "  Ipv4 {:?} => {:?}",
+                        value.source_addr(),
+                        value.destination_addr()
+                    );
+                    if !extensions.is_empty() {
+                        println!("    {extensions:?}");
+                    }
+                }
+                Some(Ipv6(value, extensions)) => {
+                    println!(
+                        "  Ipv6 {:?} => {:?}",
+                        value.source_addr(),
+                        value.destination_addr()
+                    );
+                    if !extensions.is_empty() {
+                        println!("    {extensions:?}");
+                    }
+                }
+                None => {}
+            }
+
+            // Print transport layer information if available.
+            match value.transport {
+                Some(Icmpv4(value)) => println!(" Icmpv4 {value:?}"),
+                Some(Icmpv6(value)) => println!(" Icmpv6 {value:?}"),
+                Some(Udp(value)) => println!(
+                    "   UDP {:?} -> {:?}",
+                    value.source_port(),
+                    value.destination_port()
+                ),
+                Some(Tcp(value)) => {
+                    println!(
+                        "   TCP {:?} -> {:?}",
+                        value.source_port(),
+                        value.destination_port()
+                    );
+                }
+                Some(Unknown(ip_protocol)) => {
+                    println!("  Unknown Protocol (ip protocol number {ip_protocol:?})")
+                }
+                None => {}
+            }
+        }
+    }
+}

--- a/examples/filter.rs
+++ b/examples/filter.rs
@@ -667,7 +667,7 @@ fn main() -> Result<()> {
     let mut ib = ndisapi::IntermediateBuffer::default();
 
     // Initialize EthPacket to pass to driver API
-    let mut packet = ndisapi::EthRequest {
+    let packet = ndisapi::EthRequest {
         adapter_handle: adapters[interface_index].get_handle(),
         packet: ndisapi::EthPacket {
             buffer: &mut ib as *mut ndisapi::IntermediateBuffer,
@@ -678,7 +678,7 @@ fn main() -> Result<()> {
         unsafe {
             WaitForSingleObject(event, u32::MAX);
         }
-        while unsafe { driver.read_packet(&mut packet) }.ok().is_some() {
+        while unsafe { driver.read_packet(&packet) }.ok().is_some() {
             // Print packet information
             if ib.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
                 println!("\nMSTCP --> Interface ({} bytes)\n", ib.get_length());

--- a/examples/filter.rs
+++ b/examples/filter.rs
@@ -16,7 +16,7 @@ use windows::{
     core::Result,
     Win32::Foundation::HANDLE,
     Win32::Networking::WinSock::{IN_ADDR, IN_ADDR_0, IN_ADDR_0_0},
-    Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
+    Win32::{System::Threading::{CreateEventW, SetEvent, WaitForSingleObject, ResetEvent}, Foundation::CloseHandle},
 };
 
 #[derive(Parser)]
@@ -702,6 +702,20 @@ fn main() -> Result<()> {
                 }
             }
         }
+
+        unsafe {
+            ResetEvent(event); // Reset the event to continue waiting for packets to arrive.
+        }
+    }
+
+    // Put the network interface into default mode.
+    driver.set_adapter_mode(
+        adapters[interface_index].get_handle(),
+        ndisapi::FilterFlags::default(),
+    )?;
+
+    unsafe {
+        CloseHandle(event); // Close the event handle.
     }
 
     Ok(())

--- a/examples/listadapters.rs
+++ b/examples/listadapters.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
     for (index, adapter) in adapters.iter().enumerate() {
         // Display the information about each network interface provided by the get_tcpip_bound_adapters_info
         let network_interface_name = Ndisapi::get_friendly_adapter_name(adapter.get_name())
-            .expect("Unkown network interface");
+            .expect("Unknown network interface");
         println!(
             "{}. {}\n\t{}",
             index + 1,

--- a/examples/packthru.rs
+++ b/examples/packthru.rs
@@ -9,7 +9,7 @@ use etherparse::{InternetSlice::*, LinkSlice::*, TransportSlice::*, *};
 use windows::{
     core::Result,
     Win32::Foundation::HANDLE,
-    Win32::System::Threading::{CreateEventW, WaitForSingleObject},
+    Win32::{System::Threading::{CreateEventW, WaitForSingleObject, ResetEvent}, Foundation::CloseHandle},
 };
 
 #[derive(Parser)]
@@ -157,6 +157,20 @@ fn main() -> Result<()> {
                 break;
             }
         }
+
+        unsafe {
+            ResetEvent(event); // Reset the event to continue waiting for packets to arrive.
+        }
+    }
+
+    // Put the network interface into default mode.
+    driver.set_adapter_mode(
+        adapters[interface_index].get_handle(),
+        ndisapi::FilterFlags::default(),
+    )?;
+
+    unsafe {
+        CloseHandle(event); // Close the event handle.
     }
 
     Ok(())

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -8,7 +8,10 @@ use etherparse::{InternetSlice::*, LinkSlice::*, TransportSlice::*, *};
 use windows::{
     core::Result,
     Win32::Foundation::HANDLE,
-    Win32::System::Threading::{CreateEventW, WaitForSingleObject},
+    Win32::{
+        Foundation::CloseHandle,
+        System::Threading::{CreateEventW, ResetEvent, WaitForSingleObject},
+    },
 };
 
 #[derive(Parser)]
@@ -128,6 +131,20 @@ fn main() -> Result<()> {
                 break;
             }
         }
+
+        unsafe {
+            ResetEvent(event); // Reset the event to continue waiting for packets to arrive.
+        }
+    }
+
+    // Put the network interface into default mode.
+    driver.set_adapter_mode(
+        adapters[interface_index].get_handle(),
+        ndisapi::FilterFlags::default(),
+    )?;
+
+    unsafe {
+        CloseHandle(event); // Close the event handle.
     }
 
     // Return the result.

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
     let mut ib = ndisapi::IntermediateBuffer::default();
 
     // Initialize EthPacket to pass to driver API
-    let mut packet = ndisapi::EthRequest {
+    let packet = ndisapi::EthRequest {
         adapter_handle: adapters[interface_index].get_handle(),
         packet: ndisapi::EthPacket {
             buffer: &mut ib as *mut ndisapi::IntermediateBuffer,
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
         unsafe {
             WaitForSingleObject(event, u32::MAX);
         }
-        while unsafe { driver.read_packet(&mut packet) }.ok().is_some() {
+        while unsafe { driver.read_packet(&packet) }.ok().is_some() {
             // Print packet information
             if ib.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
                 println!(

--- a/examples/passthru.rs
+++ b/examples/passthru.rs
@@ -22,52 +22,59 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
+    // Parse command line arguments and extract interface index and number of packets
     let Cli {
         mut interface_index,
         mut packets_number,
     } = Cli::parse();
 
+    // Subtract 1 from interface index to convert from 1-based to 0-based indexing
     interface_index -= 1;
 
+    // Create new NDISAPI object using the WinpkFilter driver
     let driver = ndisapi::Ndisapi::new("NDISRD")
         .expect("WinpkFilter driver is not installed or failed to load!");
 
+    // Print the version of Windows Packet Filter detected by the driver API
     println!(
         "Detected Windows Packet Filter version {}",
         driver.get_version()?
     );
 
+    // Get information about TCP/IP adapters bound to the driver
     let adapters = driver.get_tcpip_bound_adapters_info()?;
 
+    // If the specified interface index is greater than the number of available interfaces, panic with an error message
     if interface_index + 1 > adapters.len() {
-        panic!("Interface index is beoynd the number of available interfaces");
+        panic!("Interface index is beyond the number of available interfaces");
     }
 
+    // Print a message showing the interface name and the number of packets being used.
     println!(
         "Using interface {} with {} packets",
         adapters[interface_index].get_name(),
         packets_number
     );
 
-    // Create Win32 event
+    // Create a Win32 event for packet handling.
     let event: HANDLE;
     unsafe {
-        event = CreateEventW(None, true, false, None)?;
+        event = CreateEventW(None, true, false, None)?; // Creating a Win32 event without a name.
     }
 
-    // Set the event within the driver
+    // Set the created event within the driver to signal completion of packet handling.
     driver.set_packet_event(adapters[interface_index].get_handle(), event)?;
 
-    // Put network interface into the tunnel mode
+    // Put the network interface into tunnel mode by setting it's filter flags.
     driver.set_adapter_mode(
         adapters[interface_index].get_handle(),
         ndisapi::FilterFlags::MSTCP_FLAG_SENT_RECEIVE_TUNNEL,
     )?;
 
-    // Allocate single IntermediateBuffer on the stack
+    // Allocate single IntermediateBuffer on the stack.
     let mut ib = ndisapi::IntermediateBuffer::default();
 
-    // Initialize EthPacket to pass to driver API
+    // Initialize EthPacket to pass to the driver API.
     let mut packet = ndisapi::EthRequest {
         adapter_handle: adapters[interface_index].get_handle(),
         packet: ndisapi::EthPacket {
@@ -75,12 +82,13 @@ fn main() -> Result<()> {
         },
     };
 
+    // Loop through all the packets from the network until we are done.
     while packets_number > 0 {
         unsafe {
-            WaitForSingleObject(event, u32::MAX);
+            WaitForSingleObject(event, u32::MAX); // Wait for the event to finish before continuing.
         }
         while unsafe { driver.read_packet(&mut packet) }.ok().is_some() {
-            // Print packet information
+            // Check if the packet is being sent or received and print message.
             if ib.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
                 println!(
                     "\nMSTCP --> Interface ({} bytes) remaining packets {}\n",
@@ -95,13 +103,13 @@ fn main() -> Result<()> {
                 );
             }
 
-            // Decrement packets counter
+            // Decrement the number of packets.
             packets_number -= 1;
 
-            // Print some informations about the sliced packet
+            // Print some information about the sliced packet headers.
             print_packet_info(&mut ib);
 
-            // Re-inject the packet back into the network stack
+            // Re-inject the packet back into the network stack.
             if ib.get_device_flags() == ndisapi::DirectionFlags::PACKET_FLAG_ON_SEND {
                 match unsafe { driver.send_packet_to_adapter(&packet) } {
                     Ok(_) => {}
@@ -114,6 +122,7 @@ fn main() -> Result<()> {
                 }
             }
 
+            // Check if we're done filtering all packets, and then break out of the loop.
             if packets_number == 0 {
                 println!("Filtering complete\n");
                 break;
@@ -121,6 +130,7 @@ fn main() -> Result<()> {
         }
     }
 
+    // Return the result.
     Ok(())
 }
 

--- a/src/async_ndisapi.rs
+++ b/src/async_ndisapi.rs
@@ -1,0 +1,418 @@
+//! # Module: ASYNC NDISAPI
+//!
+//! This module contains the `NdisapiAdapter` struct, an abstraction for a network adapter that is controlled via the 
+//! Windows Packet Filter NDISAPI interface. 
+//!
+//! `NdisapiAdapter` provides asynchronous methods for managing and interacting with the network adapter. This includes
+//! reading and writing Ethernet packets, and adjusting adapter settings. This is achieved through the use of `async` functions,
+//! which allow these operations to be performed without blocking the rest of your application. 
+//!
+//! With the help of the NDISAPI, `NdisapiAdapter` can directly interact with the network adapter at a low level, offering finer
+//! control and efficiency compared to the traditional sockets-based networking. This makes it particularly suited to tasks such as
+//! packet sniffing and injection, implementing custom protocols, or interacting with the adapter in unusual ways that may not be
+//! supported by the standard networking stack.
+use crate::ndisapi::{EthPacket, FilterFlags, self};
+use std::sync::Arc;
+use futures::StreamExt;
+use windows::{
+    core::Result,
+    Win32::{
+        Foundation::{GetLastError, HANDLE, WIN32_ERROR},
+        System::Threading::{
+            CreateEventW,
+        },
+    },
+};
+
+use self::win32_event_stream::Win32EventStream;
+
+// Submodules
+mod win32_event_stream;
+
+/// The struct NdisapiAdapter represents a network adapter with its associated driver and relevant handles.
+pub struct NdisapiAdapter {
+    /// The network driver for the adapter.
+    driver: Arc<ndisapi::Ndisapi>,
+    /// The handle of the network adapter.
+    adapter_handle: HANDLE,
+    /// A future that resolves when a Win32 event is signaled.
+    notif: Win32EventStream,
+}
+
+impl NdisapiAdapter {
+    /// Constructs a new `NdisapiAdapter`.
+    ///
+    /// This function takes a network driver and the handle of the network adapter as arguments.
+    /// It then creates a Win32 event and sets it for packet capture for the specified adapter.
+    /// Finally, it creates a new `NdisapiAdapter` with the driver, adapter handle, and a
+    /// `Win32EventFuture` created with the event handle.
+    ///
+    /// # Arguments
+    ///
+    /// * `driver` - An `Arc<ndisapi::Ndisapi>` that represents the network driver for the adapter.
+    /// * `adapter_handle` - A `HANDLE` that represents the handle of the network adapter.
+    ///
+    /// # Safety
+    ///
+    /// This function contains unsafe code blocks due to the FFI call to `CreateEventW`
+    /// and the potential for a null or invalid adapter handle. The caller should ensure that
+    /// the passed network driver and the adapter handle are properly initialized and safe
+    /// to use in this context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Win32 event creation fails, or if setting the packet capture event for
+    /// the adapter fails, or if creating the `Win32EventFuture` fails.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Ok(Self)` if the `NdisapiAdapter` is successfully created, where `Self` is
+    /// the newly created `NdisapiAdapter`.
+    pub fn new(
+        driver: Arc<ndisapi::Ndisapi>, // The network driver for the adapter.
+        adapter_handle: HANDLE,        // The handle of the network adapter.
+    ) -> Result<Self> {
+        let event_handle = unsafe {
+            // Creating a Win32 event without a name. The event is manual-reset and initially non-signaled.
+            CreateEventW(None, true, false, None)?
+        };
+
+        // Setting the event for packet capture for the specified adapter.
+        driver.set_packet_event(adapter_handle, event_handle)?;
+
+        Ok(Self {
+            adapter_handle,
+            driver,
+            notif: Win32EventStream::new(event_handle)?, // Creating a new Win32EventFuture with the event handle.
+        })
+    }
+
+    /// Sets the operating mode for the network adapter.
+    ///
+    /// This function takes a set of `FilterFlags` as an argument which represent the desired
+    /// operating mode, and applies them to the network adapter.
+    ///
+    /// # Arguments
+    ///
+    /// * `flags` - `FilterFlags` that represent the desired operating mode for the network adapter.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver fails to set the operating mode for the network adapter.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the operating mode was successfully set for the network adapter.
+    pub fn set_adapter_mode(&self, flags: FilterFlags) -> Result<()> {
+        self.driver.set_adapter_mode(self.adapter_handle, flags)?;
+        Ok(())
+    }
+
+    /// Reads a packet from the network adapter asynchronously and returns it as an `EthPacket`.
+    ///
+    /// This function initializes an `EthRequest` with the provided `EthPacket` and the handle to the adapter.
+    /// Then it attempts to read a packet from the network adapter. If the read operation fails,
+    /// the function awaits for a packet event before attempting the read operation again.
+    ///
+    /// # Arguments
+    ///
+    /// * `packet` - An `EthPacket` which will be filled with the data from the network adapter.
+    ///
+    /// # Safety
+    ///
+    /// This function contains unsafe code blocks due to the FFI calls to `driver.read_packet(&request)`
+    /// and the call to `GetLastError()`. Ensure the passed `EthPacket` is properly initialized
+    /// and safe to use in this context.
+    ///
+    /// The function also temporarily pins the `Win32EventFuture` instance to the stack with `Pin::new(&mut self.notif).await`.
+    /// While this is generally considered safe because `Win32EventFuture` and its internals do not move after being pinned,
+    /// and because the poll function does not invalidate or move these internals after pinning, any future changes to `Win32EventFuture` or its poll
+    /// implementation could potentially make this unsafe. Therefore, be sure to review these aspects if you modify `Win32EventFuture` or this function in the future.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver fails to read a packet from the network adapter, or if the
+    /// await operation on the packet event fails. The specific error returned in the first case is the
+    /// last error occurred, obtained via a call to `GetLastError()`.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Ok(EthPacket)` if the packet is successfully read from the network adapter,
+    /// where `EthPacket` is the original packet filled with the data from the network adapter.
+    pub async fn read_packet(&mut self, packet: EthPacket) -> Result<EthPacket> {
+        let driver = self.driver.clone();
+    
+        // Initialize EthPacket to pass to driver API.
+        let mut request = ndisapi::EthRequest {
+            adapter_handle: self.adapter_handle,
+            packet,
+        };
+    
+        // First try to read packet
+        if unsafe { driver.read_packet(&mut request) }.is_ok() {
+            return Ok(packet);
+        }
+    
+        // Wait for packet event
+        match self.notif.next().await {
+            Some(result) => {
+                match result {
+                    Ok(_) => {
+                        if unsafe { driver.read_packet(&mut request) }.is_ok() {
+                            Ok(packet)
+                        } else {
+                            Err(unsafe { GetLastError() }.into())
+                        }
+                    },
+                    Err(e) => Err(e),
+                }
+            },
+            None => {
+                // The stream is exhausted. This should never happen in our case.
+                Err(WIN32_ERROR(0u32).into())
+            }
+        }
+    }
+
+    /// Reads a number of packets from the network adapter asynchronously and returns the number of packets read.
+    ///
+    /// This function initializes an `EthMRequest` with the provided array of `EthPacket`s and the handle to the adapter.
+    /// Then it attempts to read packets from the network adapter. If the read operation fails, the function awaits a packet event
+    /// before attempting the read operation again.
+    ///
+    /// # Arguments
+    ///
+    /// * `packets` - A slice of `EthPacket`s which will be filled with the data from the network adapter.
+    ///
+    /// # Safety
+    ///
+    /// This function contains unsafe code blocks due to the FFI calls to `driver.read_packets(&mut request)` and the call to `GetLastError()`.
+    /// Ensure the passed `EthPacket`s are properly initialized and safe to use in this context.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `N`: The compile-time constant representing the maximum size of the `EthMRequest`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver fails to read packets from the network adapter, or if the await operation on the packet event fails.
+    /// The specific error returned in the first case is the last error occurred, obtained via a call to `GetLastError()`.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Ok(usize)` if the packets are successfully read from the network adapter, where `usize` is the number of packets read.
+    pub async fn read_packets<const N: usize>(&mut self, packets: &[EthPacket]) -> Result<usize> {
+        let driver = self.driver.clone();
+
+        // Initialize EthMPacket to pass to driver API.
+        let mut request = ndisapi::EthMRequest::<N>::new(self.adapter_handle);
+
+        // Push packets to request
+        request.push_slice(packets)?;
+
+        // first try to read packets
+        if unsafe { driver.read_packets(&mut request) }.is_ok() {
+            return Ok(request.get_packet_success() as usize);
+        }
+
+         // Wait for packet event
+         match self.notif.next().await {
+            Some(result) => {
+                match result {
+                    Ok(_) => {
+                        if unsafe { driver.read_packets(&mut request) }.ok().is_some() {
+                            Ok(request.get_packet_success() as usize)
+                        } else {
+                            Err(unsafe { GetLastError() }.into())
+                        }
+                    },
+                    Err(e) => Err(e),
+                }
+            },
+            None => {
+                // The stream is exhausted. This should never happen in our case.
+                Err(WIN32_ERROR(0u32).into())
+            }
+        }
+    }
+
+    /// Sends an Ethernet packet to the network adapter.
+    ///
+    /// This function takes an `EthPacket` as an argument and passes it to the network adapter.
+    /// This is achieved by creating an `EthRequest` structure which contains the `EthPacket`
+    /// and the handle to the adapter, and then passing this request to the driver API.
+    ///
+    /// # Arguments
+    ///
+    /// * `packet` - An `EthPacket` that represents the Ethernet packet to be sent.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked unsafe due to the FFI call to `self.driver.send_packet_to_adapter(&request)`
+    /// and the call to `GetLastError()`. Caller should ensure that the passed `EthPacket` is properly
+    /// initialized and safe to use in this context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver fails to send the packet to the network adapter. The specific error
+    /// returned is the last error occurred, obtained via a call to `GetLastError()`.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the packet was successfully sent to the network adapter.
+    pub fn send_packet_to_adapter(&self, packet: EthPacket) -> Result<()> {
+        // Initialize EthPacket to pass to driver API.
+        let request = ndisapi::EthRequest {
+            adapter_handle: self.adapter_handle,
+            packet,
+        };
+
+        // Try to send packet to the network adapter.
+        if unsafe { self.driver.send_packet_to_adapter(&request) }.is_ok() {
+            Ok(())
+        } else {
+            Err(unsafe { GetLastError() }.into())
+        }
+    }
+
+    /// Sends a number of packets to the network adapter synchronously and returns the number of packets sent.
+    ///
+    /// This function initializes an `EthMRequest` with the provided array of `EthPacket`s and the handle to the adapter.
+    /// Then it attempts to send packets to the network adapter.
+    ///
+    /// # Arguments
+    ///
+    /// * `packets` - A slice of `EthPacket`s which will be sent to the network adapter.
+    ///
+    /// # Safety
+    ///
+    /// This function contains unsafe code blocks due to the FFI calls to `self.driver.send_packets_to_adapter(&request)` 
+    /// and the call to `GetLastError()`. Ensure the passed `EthPacket`s are properly initialized and safe to use in this context.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `N`: The compile-time constant representing the maximum size of the `EthMRequest`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver fails to send packets to the network adapter.
+    /// The specific error returned is the last error occurred, obtained via a call to `GetLastError()`.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Ok(usize)` if the packets are successfully sent to the network adapter, 
+    /// where `usize` is the number of packets sent.
+    pub fn send_packets_to_adapter<const N: usize>(&mut self, packets: &[EthPacket]) -> Result<usize> {
+        // Initialize EthMPacket to pass to driver API.
+        let mut request = ndisapi::EthMRequest::<N>::new(self.adapter_handle);
+
+        for packet in packets {
+            request.push(*packet)?;
+        }
+
+        // Try to send packets to the network adapter.
+        if unsafe { self.driver.send_packets_to_adapter(&request) }.is_ok() {
+            Ok(request.get_packet_success() as usize)
+        } else {
+            Err(unsafe { GetLastError() }.into())
+        }
+    }
+
+    /// Sends an Ethernet packet upwards the network stack to the Microsoft TCP/IP protocol driver.
+    ///
+    /// This function takes an `EthPacket` as an argument and sends it upwards the network stack.
+    /// This is accomplished by creating an `EthRequest` structure which contains the `EthPacket`
+    /// and the handle to the adapter, and then passing this request to the driver API.
+    ///
+    /// # Arguments
+    ///
+    /// * `packet` - An `EthPacket` that represents the Ethernet packet to be sent.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked unsafe due to the FFI call to `self.driver.send_packet_to_mstcp(&request)`
+    /// and the call to `GetLastError()`. Ensure that the passed `EthPacket` is properly initialized
+    /// and safe to use in this context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver fails to send the packet upwards the network stack. The specific error
+    /// returned is the last error occurred, obtained via a call to `GetLastError()`.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the packet was successfully sent upwards the network stack.
+    pub fn send_packet_to_mstcp(&self, packet: EthPacket) -> Result<()> {
+        // Initialize EthPacket to pass to driver API.
+        let request = ndisapi::EthRequest {
+            adapter_handle: self.adapter_handle,
+            packet,
+        };
+
+        // Try to send packet upwards the network stack.
+        if unsafe { self.driver.send_packet_to_mstcp(&request) }.is_ok() {
+            Ok(())
+        } else {
+            Err(unsafe { GetLastError() }.into())
+        }
+    }
+
+    /// Sends a number of packets upwards the network stack synchronously and returns the number of packets sent.
+    ///
+    /// This function initializes an `EthMRequest` with the provided array of `EthPacket`s and the handle to the adapter.
+    /// Then it attempts to send packets to the network stack.
+    ///
+    /// # Arguments
+    ///
+    /// * `packets` - A slice of `EthPacket`s which will be sent upwards the network stack.
+    ///
+    /// # Safety
+    ///
+    /// This function contains unsafe code blocks due to the FFI calls to `self.driver.send_packets_to_mstcp(&request)`
+    /// and the call to `GetLastError()`. Ensure the passed `EthPacket`s are properly initialized and safe to use in this context.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `N`: The compile-time constant representing the maximum size of the `EthMRequest`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver fails to send packets to the network stack.
+    /// The specific error returned is the last error occurred, obtained via a call to `GetLastError()`.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Ok(usize)` if the packets are successfully sent to the network stack, 
+    /// where `usize` is the number of packets sent.
+    pub fn send_packets_to_mstcp<const N: usize>(&mut self, packets: &[EthPacket]) -> Result<usize> {
+        // Initialize EthMPacket to pass to driver API.
+        let mut request = ndisapi::EthMRequest::<N>::new(self.adapter_handle);
+
+        for packet in packets {
+            request.push(*packet)?;
+        }
+
+        // Try to send packets upwards the network stack.
+        if unsafe { self.driver.send_packets_to_mstcp(&request) }.is_ok() {
+            Ok(request.get_packet_success() as usize)
+        } else {
+            Err(unsafe { GetLastError() }.into())
+        }
+    }
+}
+
+// Implementing the Drop trait for the NdisapiAdapter struct.
+impl Drop for NdisapiAdapter {
+    /// The drop method will be called automatically when the NdisapiAdapter object goes out of scope.
+    fn drop(&mut self) {
+        // Setting the operating mode for the specified adapter to default.
+        _ = self
+            .driver
+            .set_adapter_mode(self.adapter_handle, FilterFlags::from_bits_truncate(0));
+
+        // Setting the packet event for the specified adapter to NULL.
+        _ = self
+            .driver
+            .set_packet_event(self.adapter_handle, HANDLE(0isize));
+    }
+}

--- a/src/async_ndisapi/win32_event_stream.rs
+++ b/src/async_ndisapi/win32_event_stream.rs
@@ -1,0 +1,186 @@
+//! # Submodule: Win32EventFuture
+//!
+//! The submodule contains two main structures: `Win32EventFuture` and `Win32EventNotification`. 
+//! These types are used to interface with the Win32 API for event-driven asynchronous programming.
+//!
+//! `Win32EventFuture` represents a future that resolves when a specific Win32 event is signaled. 
+//! It encapsulates a `Win32EventNotification` object (the Win32 event notification object), 
+//! an `AtomicWaker` (used to wake up the future when it's ready to make progress), 
+//! and an `AtomicBool` (indicating whether the event is ready or not). 
+//!
+//! An instance of `Win32EventFuture` can be created with a given Win32 event handle, 
+//! and can be polled to check if the packet event is ready.
+//!
+//! The `Win32EventFuture` struct implements the `Future` trait, making it possible to use 
+//! it with async/await syntax and within other futures or async functions.
+//!
+//! `Win32EventNotification` encapsulates a Win32 event and provides a mechanism to register 
+//! a callback function that is called when the event is signaled. It maintains the Win32 event handle, 
+//! the wait object handle, and a pointer to the callback function. It also implements the `Drop` trait 
+//! to ensure proper cleanup of its resources when it goes out of scope.
+//!
+//! This submodule provides an abstraction over the Win32 event handling mechanism, providing a Rust-friendly, 
+//! safe, and idiomatic way to work with Win32 events in an asynchronous context. 
+//! This can be especially useful in scenarios involving network I/O, inter-process communication, 
+//! or any other situation where you need to wait for an event to occur without blocking your application.
+use futures::{task::AtomicWaker, Stream, stream::FusedStream};
+use std::{
+    ffi::c_void,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+};
+use windows::{
+    core::Result,
+    Win32::{
+        Foundation::{CloseHandle, GetLastError, BOOLEAN, HANDLE},
+        System::Threading::{
+            RegisterWaitForSingleObject, ResetEvent, UnregisterWaitEx, INFINITE,
+            WT_EXECUTEINWAITTHREAD,
+        },
+    },
+};
+
+/// A future that resolves when a Win32 event is signaled.
+pub struct Win32EventStream {
+    #[allow(dead_code)]
+    /// The Win32 event notification object.
+    notif: Win32EventNotification, 
+    /// An atomic waker for waking the future.
+    waker: Arc<AtomicWaker>, 
+    /// An atomic boolean indicating whether the event is ready.
+    ready: Arc<AtomicBool>,  
+}
+
+impl Win32EventStream {
+    /// Create a new `Win32EventFuture` instance with the specified event handle.
+    pub fn new(event_handle: HANDLE) -> Result<Self> {
+        let waker = Arc::new(AtomicWaker::new());
+        let ready = Arc::new(AtomicBool::new(false));
+
+        Ok(Self {
+            waker: waker.clone(),
+            ready: ready.clone(),
+            notif: Win32EventNotification::new(
+                event_handle,
+                Box::new(move |_| {
+                    ready.store(true, Ordering::SeqCst);
+                    waker.wake();
+                    unsafe { ResetEvent(event_handle) };
+                }),
+            )?,
+        })
+    }
+}
+
+impl Stream for Win32EventStream {
+    type Item = Result<()>;
+
+    /// Polls the stream to check if the event is ready.
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = Pin::into_inner(self);
+
+        if this.ready.swap(false, Ordering::Relaxed) {
+            // The Win32 event is ready, so we clear the ready flag and wake the waker, if present.
+            // Then we reset the event to non-signaled state.
+            // We signal readiness by returning `Poll::Ready`.
+            Poll::Ready(Some(Ok(())))
+        } else {
+            // The Win32 event is not ready, so we register the waker and return `Poll::Pending`.
+            this.waker.register(cx.waker());
+            Poll::Pending
+        }
+    }
+}
+
+impl FusedStream for Win32EventStream {
+    fn is_terminated(&self) -> bool {
+        false
+    }
+}
+
+/// Win32 event notifications
+struct Win32EventNotification {
+    win32_event: HANDLE,               // The Win32 event handle.
+    wait_object: HANDLE,               // The wait object handle.
+    callback: *mut Win32EventCallback, // A pointer to the Win32 event callback function.
+}
+
+/// Implementing the Debug trait for the Win32EventNotification struct.
+impl std::fmt::Debug for Win32EventNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Win32EventNotification: {:?}", self.wait_object)
+    }
+}
+
+type Win32EventCallback = Box<dyn Fn(BOOLEAN) + Send>; // A type alias for the Win32 event callback function.
+
+impl Win32EventNotification {
+    /// Register for Win32 event notifications.
+    fn new(win32_event: HANDLE, cb: Win32EventCallback) -> Result<Self> {
+        // Defining the global callback function for the Win32 event.
+        unsafe extern "system" fn global_callback(caller_context: *mut c_void, time_out: BOOLEAN) {
+            (**(caller_context as *mut Win32EventCallback))(time_out)
+        }
+
+        let callback = Box::into_raw(Box::new(cb)); // Creating a raw pointer to the callback function.
+        let mut wait_object: HANDLE = HANDLE(0isize);
+
+        // Registering for Win32 event notifications.
+        let rc = unsafe {
+            RegisterWaitForSingleObject(
+                &mut wait_object,
+                win32_event,
+                Some(global_callback),
+                Some(callback as *const c_void),
+                INFINITE,
+                WT_EXECUTEINWAITTHREAD,
+            )
+        };
+
+        // Check if the registration was successful.
+        if rc.as_bool() {
+            Ok(Self {
+                callback,
+                win32_event,
+                wait_object,
+            })
+        } else {
+            drop(unsafe { Box::from_raw(callback) }); // Dropping the callback function.
+            Err(unsafe { GetLastError() }.into())
+        }
+    }
+}
+
+impl Drop for Win32EventNotification {
+    /// Implementing the Drop trait for the Win32EventNotification struct.
+    fn drop(&mut self) {
+        unsafe {
+            // Deregistering the wait object.
+            if !UnregisterWaitEx(self.wait_object, self.win32_event).as_bool() {
+                //log::error!("error deregistering notification: {}", GetLastError);
+            }
+            drop(Box::from_raw(self.callback)); // Dropping the callback function.
+        }
+
+        unsafe {
+            // Closing the handle to the event.
+            CloseHandle(self.win32_event);
+        }
+    }
+}
+
+/// # Safety
+/// `Win32EventNotification` is safe to send between threads because it does not
+/// encompass any thread-specific data (like `std::rc::Rc` or `std::cell::RefCell`)
+/// and does not provide mutable access to its data across different threads
+/// (like `std::sync::Arc`).
+/// The Windows API functions that we're using (`RegisterWaitForSingleObject`,
+/// `UnregisterWaitEx`, and `CloseHandle`) are all thread-safe as per the
+/// Windows API documentation. Our struct only contains raw pointers and handles
+/// that are essentially IDs which can be freely copied and are not tied to a
+/// specific thread. As such, it's safe to implement Send for this type.
+unsafe impl Send for Win32EventNotification {}

--- a/src/async_ndisapi/win32_event_stream.rs
+++ b/src/async_ndisapi/win32_event_stream.rs
@@ -1,18 +1,18 @@
-//! # Submodule: Win32EventFuture
+//! # Submodule: Win32EventStream
 //!
-//! The submodule contains two main structures: `Win32EventFuture` and `Win32EventNotification`.
+//! The submodule contains two main structures: `Win32EventStream` and `Win32EventNotification`.
 //! These types are used to interface with the Win32 API for event-driven asynchronous programming.
 //!
-//! `Win32EventFuture` represents a future that resolves when a specific Win32 event is signaled.
+//! `Win32EventStream` represents a stream of events coming from a specific Win32 event.
 //! It encapsulates a `Win32EventNotification` object (the Win32 event notification object),
-//! an `AtomicWaker` (used to wake up the future when it's ready to make progress),
+//! an `AtomicWaker` (used to wake up the stream when new events are ready to be processed),
 //! and an `AtomicBool` (indicating whether the event is ready or not).
 //!
-//! An instance of `Win32EventFuture` can be created with a given Win32 event handle,
-//! and can be polled to check if the packet event is ready.
+//! An instance of `Win32EventStream` can be created with a given Win32 event handle,
+//! and can be polled to check if new events are ready.
 //!
-//! The `Win32EventFuture` struct implements the `Future` trait, making it possible to use
-//! it with async/await syntax and within other futures or async functions.
+//! The `Win32EventStream` struct implements the `Stream` trait, making it possible to use
+//! it with async/await syntax and within other futures, streams or async functions.
 //!
 //! `Win32EventNotification` encapsulates a Win32 event and provides a mechanism to register
 //! a callback function that is called when the event is signaled. It maintains the Win32 event handle,
@@ -44,7 +44,7 @@ use windows::{
     },
 };
 
-/// A future that resolves when a Win32 event is signaled.
+/// A stream that resolves when a Win32 event is signaled.
 pub struct Win32EventStream {
     #[allow(dead_code)]
     /// The Win32 event notification object.
@@ -56,7 +56,7 @@ pub struct Win32EventStream {
 }
 
 impl Win32EventStream {
-    /// Create a new `Win32EventFuture` instance with the specified event handle.
+    /// Create a new `Win32EventStream` instance with the specified event handle.
     pub fn new(event_handle: HANDLE) -> Result<Self> {
         let waker = Arc::new(AtomicWaker::new());
         let ready = Arc::new(AtomicBool::new(false));

--- a/src/driver/base.rs
+++ b/src/driver/base.rs
@@ -191,6 +191,21 @@ pub struct EthPacket {
 }
 
 impl EthPacket {
+    /// Create a new `EthPacket` instance with the specified IntermediateBuffer reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - A mutable reference to an `IntermediateBuffer` representing the buffer for this Ethernet packet.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it creates a raw pointer from the provided mutable reference.
+    /// The caller must ensure that the `IntermediateBuffer` outlives the `EthPacket` object.
+    /// Failing to uphold this guarantee may lead to undefined behavior.
+    pub unsafe fn new(buffer: &mut IntermediateBuffer) -> Self {
+        Self { buffer: buffer as *mut _ }
+    }
+
     /// Returns a mutable reference to the `IntermediateBuffer` pointed to by the `EthPacket`.
     ///
     /// # Safety
@@ -291,6 +306,14 @@ impl<const N: usize> EthMRequest<N> {
         } else {
             Err(ERROR_INVALID_PARAMETER.into())
         }
+    }
+
+    /// Pushes a slice of `EthPacket` to the `packets` array if there's available space, returning an error if the array becomes full.
+    pub fn push_slice(&mut self, packets: &[EthPacket]) -> Result<()> {
+        for packet in packets {
+            self.push(*packet)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 mod driver;
 mod ndisapi;
 mod net;
+#[cfg(feature = "async")]
+mod async_ndisapi;
 
 pub use crate::ndisapi::{
     DirectionFlags, Eth802_3FilterFlags, EthMRequest, EthPacket, EthRequest, FastIoSection,
@@ -23,5 +25,8 @@ pub use crate::ndisapi::{
     ICMP, IPV4, IPV6, IP_RANGE_V4_TYPE, IP_RANGE_V6_TYPE, IP_SUBNET_V4_TYPE, IP_SUBNET_V6_TYPE,
     TCPUDP,
 };
+
+#[cfg(feature = "async")]
+pub use crate::async_ndisapi::NdisapiAdapter;
 
 pub use net::MacAddress;

--- a/src/ndisapi.rs
+++ b/src/ndisapi.rs
@@ -19,8 +19,7 @@ use windows::{
     Win32::Foundation::CloseHandle,
     Win32::Foundation::{GetLastError, HANDLE},
     Win32::Storage::FileSystem::{
-        CreateFileW, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE,
-        OPEN_EXISTING,
+        CreateFileW, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
     },
 };
 
@@ -48,6 +47,7 @@ pub use crate::driver::*;
 /// For example, you can use the `Ndisapi::read_packets()` method to read packets from the network adapter, or the `Ndisapi::send_packets_to_adapter()`
 /// method to write packets to the network adapter. You can also use the `Ndisapi::set_packet_filter_table()` method to set a filter that specifies which
 /// packets should be captured or dropped.
+#[derive(Debug, Clone)]
 pub struct Ndisapi {
     // Represents a handle to the NDIS filter driver.
     driver_handle: HANDLE,

--- a/src/ndisapi.rs
+++ b/src/ndisapi.rs
@@ -19,8 +19,7 @@ use windows::{
     Win32::Foundation::CloseHandle,
     Win32::Foundation::{GetLastError, HANDLE},
     Win32::Storage::FileSystem::{
-        CreateFileW, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE,
-        OPEN_EXISTING,
+        CreateFileW, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
     },
 };
 

--- a/src/ndisapi/io_api.rs
+++ b/src/ndisapi/io_api.rs
@@ -97,21 +97,21 @@ impl Ndisapi {
     ///
     /// # Arguments
     ///
-    /// * `packet: &mut EthRequest`: A mutable reference to the `EthRequest` structure that will be filled with
-    ///   the retrieved packet data.
+    /// * `packet: &EthRequest`: This is a reference to the EthRequest structure. It encompasses an
+    /// intermediate buffer pointer which is designed to be populated with the retrieved packet data.
     ///
     /// # Returns
     ///
     /// * `Result<()>`: If successful, returns `Ok(())`. Otherwise, returns an error.
-    pub unsafe fn read_packet(&self, packet: &mut EthRequest) -> Result<()> {
+    pub unsafe fn read_packet(&self, packet: &EthRequest) -> Result<()> {
         let result = unsafe {
             DeviceIoControl(
                 self.driver_handle,
                 IOCTL_NDISRD_READ_PACKET,
                 Some(packet as *const EthRequest as *const std::ffi::c_void),
                 size_of::<EthRequest>() as u32,
-                Some(packet as *mut EthRequest as *mut std::ffi::c_void),
-                size_of::<EthRequest>() as u32,
+                None,
+                0u32,
                 None,
                 None,
             )


### PR DESCRIPTION
This PR introduces asynchronous extensions to the NDISAPI. The primary aim of these extensions is to provide non-blocking I/O operations, enhancing the library's performance by leveraging Rust's async/await syntax and the futures library.
In order to demonstrate the newly added async functionalities, two sample applications, async_packthru.rs and async_passthru.rs, have been included in this commit. These samples showcase the practical usage and benefits of the asynchronous extensions in real-world scenarios.